### PR TITLE
FIX EC11 Driver, add interrupt support, add 12 different orders.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.16)
+
+
+#Here we include only components required by target esp32p4.
+if(IDF_TARGET STREQUAL "esp32p4")
+    set(EXTRA_COMPONENT_DIRS
+    "${CMAKE_SOURCE_DIR}/esp32p4_components"
+    ./esp32p4_components/bsp_extra
+    )
+
+    set(SRCS "")
+
+    set(INCLUDE_DIRS "")
+    list(APPEND INCLUDE_DIRS "include")
+
+    list(APPEND SRCS
+        "src/bsp_board_extra.c"
+    )
+
+    foreach(SRC_DIR IN LISTS SRC_DIRS)
+        file(GLOB_RECURSE SRC ${SRC_DIR}/*.c)
+        list(APPEND SRCS ${SRC})
+        list(APPEND INCLUDE_DIRS ${SRC_DIR}/include)
+    endforeach()
+
+endif()
+
+#Here we manage sdk configs with a shared configuration and one specific per target.
+set(SDKCONFIG_DEFAULTS
+  "${CMAKE_SOURCE_DIR}/sdkconfig.defaults"
+)
+
+if(IDF_TARGET STREQUAL "esp32s3")
+  list(APPEND SDKCONFIG_DEFAULTS
+    "${CMAKE_SOURCE_DIR}/sdkconfig.defaults.esp32s3")
+elseif(IDF_TARGET STREQUAL "esp32p4")
+  list(APPEND SDKCONFIG_DEFAULTS
+    "${CMAKE_SOURCE_DIR}/sdkconfig.defaults.esp32p4")
+endif()
+
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(rb_project)

--- a/main/MS4525DO/LICENSE
+++ b/main/MS4525DO/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 nopnop2002
+Copyright (c) 2025 The_MiNuS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/main/RB/RB02.c
+++ b/main/RB/RB02.c
@@ -56,14 +56,14 @@
  * - ESP32-S3 2.8" Inch Round display 480x480 TOUCH
  * - https://www.waveshare.com/esp32-s3-touch-lcd-2.8c.htm
  */
- /*void DidYouJoinedDiscord()
+void DidYouJoinedDiscord()
 {
 
   if (youAreThere == true)
   {
     MeansYouShallUseThePreBuildReleasedAndJoinDiscord();
   }
-}*/
+}
 
 #include "RB02.h"
 #include "RB02_GUIHelpers.h"

--- a/main/RB/RB02.c
+++ b/main/RB/RB02.c
@@ -56,14 +56,14 @@
  * - ESP32-S3 2.8" Inch Round display 480x480 TOUCH
  * - https://www.waveshare.com/esp32-s3-touch-lcd-2.8c.htm
  */
- void DidYouJoinedDiscord()
+ /*void DidYouJoinedDiscord()
 {
 
   if (youAreThere == true)
   {
     MeansYouShallUseThePreBuildReleasedAndJoinDiscord();
   }
-}
+}*/
 
 #include "RB02.h"
 #include "RB02_GUIHelpers.h"
@@ -150,16 +150,8 @@
 
 #ifdef RB_ENABLE_NavCore
 #include "RB02_NavCore.h"
-#include "ms4525do_rb.h"
-int32_t NavCore_GetEncoderDelta(void);
-bool NavCore_GetAndClearSwitchPressed(void);
 #endif
 
-#ifdef RB_ENABLE_NavCore
-#include "sc16is750.h"
-#include "driver/gpio.h"
-#include "freertos/stream_buffer.h"
-#endif
 #include "PCF85063.h"
 #include "RB02_SDCardInject.c"
 
@@ -1087,13 +1079,17 @@ void uart_fetch_data()
 {
   if (GpsSpeed0ForDisable == 0)
     return;
-
 #ifdef RB_ENABLE_NavCore
   // In NavCore mode, SC16IS IRQ task fills a stream buffer. We only drain it here and parse NMEA
   // from the main context (safer for LVGL/UI code paths).
   static uint8_t data[UART_RX_BUF_SIZE + 1];
 
-  size_t rxBytes = xStreamBufferReceive(g_navcore_gps_sb, data, UART_RX_BUF_SIZE, 0);
+  //size_t rxBytes = xStreamBufferReceive(g_navcore_gps_sb, data, UART_RX_BUF_SIZE, 0);
+  StreamBufferHandle_t sb = rb_navcore_gps_stream();
+  size_t rxBytes = 0;
+  if (sb) {
+    rxBytes = xStreamBufferReceive(sb, data, UART_RX_BUF_SIZE, 0);
+  }
   if (rxBytes > 0)
   {
     data[rxBytes] = 0;
@@ -1965,7 +1961,7 @@ void update_Speed_lvgl_tick(lv_timer_t *t)
     lv_label_set_text(singletonConfig()->ui.labelGPSSpeed, buf);
 
 #if defined(RB_ENABLE_IAS)
-    snprintf(buf, sizeof(buf), "%.0f", (float)speed / isKt); // KT
+    snprintf(buf, sizeof(buf), "%.0f", (float)speed / 10 / isKt); // KT
     lv_label_set_text(singletonConfig()->ui.labelIASSpeed, buf);
 #endif
   }
@@ -2019,11 +2015,7 @@ void uartApplyRates()
   {
 #ifdef RB_ENABLE_UART
 #ifdef RB_ENABLE_NavCore
-  // NavCore: SC16IS762 on existing I2C bus (GPIO07/15) + IRQ on GPIO19
-  if (!g_navcore_sc_inited)
-  {
-    NavCore_SC16_Init();
-  }
+    rb_navcore_init();
 #else
     const uart_config_t uart_config = {
         .baud_rate = GpsSpeed0ForDisable, // TODO: Delay the setup up to the LVGL started
@@ -3294,6 +3286,59 @@ static void speedBgClicked(lv_event_t *event)
     nvsStoreDefaultScreenOrDemo();
   }
 }
+
+#ifdef RB_ENABLE_NavCore
+void RB02_NavCore_InjectTouch(uint8_t touch_loc)
+{
+  // Same protections as speedBgClicked
+  if (mbox1 != NULL)
+    return;
+
+  if (tv == NULL)
+    return;
+
+  bool changedTab = false;
+  lv_tabview_t *tabview = (lv_tabview_t *)tv;
+  uint16_t cur = tabview->tab_cur;
+
+  // Reproduce the "global" W/E tab switching behavior from speedBgClicked()
+  switch (touch_loc)
+  {
+    case RB02_TOUCHLOC_W:
+      if (cur > 0)
+      {
+        cur--;
+        changedTab = true;
+      }
+      break;
+
+    case RB02_TOUCHLOC_E:
+      cur++;
+      changedTab = true;
+      if (cur >= RB02_TAB_DEV)
+      {
+        cur = RB02_TAB_SET;
+      }
+      break;
+
+    default:
+      // For N/S/CENTER etc, reuse RB02 dispatching
+      actionInTab((touchLocation)touch_loc);
+      break;
+  }
+
+  if (changedTab)
+  {
+    lv_tabview_set_act(tv, cur, LV_ANIM_OFF);
+
+    if (DeviceIsDemoMode == 0)
+    {
+      nvsStoreDefaultScreenOrDemo();
+    }
+  }
+}
+#endif
+
 
 static lv_obj_t *Onboard_create_Base(lv_obj_t *parent, const lv_img_dsc_t *backgroundImageName)
 {

--- a/main/RB/RB02.h
+++ b/main/RB/RB02.h
@@ -41,4 +41,5 @@ The source code should only be used as an example for those who have the skills 
 To support you, we've created a community on Discord. Join us and learn how the devices work.
 We thank you for your support and sponsorship.
  */
-#error You shall not compile yourself, please use the official releases and join the discord community
+
+// #error You shall not compile yourself, please use the official releases and join the discord community

--- a/main/RB/RB02.h
+++ b/main/RB/RB02.h
@@ -42,4 +42,4 @@ To support you, we've created a community on Discord. Join us and learn how the 
 We thank you for your support and sponsorship.
  */
 
-// #error You shall not compile yourself, please use the official releases and join the discord community
+ #error You shall not compile yourself, please use the official releases and join the discord community

--- a/main/RB/RB02_NavCore.c
+++ b/main/RB/RB02_NavCore.c
@@ -27,104 +27,457 @@
  *
 */
 
-#include "RB02_NavCore.h"
 
-#ifdef RB_ENABLE_NavCore
-int32_t NavCore_GetEncoderDelta(void);
-bool NavCore_GetAndClearSwitchPressed(void);
+/*
+ * @file RB02_NavCore.c
+ * Author: The_MiNuS (2025)
+*/
+
+#include "RB02_NavCore.h"
+#include "RB02.h"
+
+
+#include <string.h>
+
+
+navcore_ec11_t g_navcore_ec11;
+
+// ---- Ordered event queue (ring) ----
+static inline void ec11_q_push(navcore_ec11_t *e, uint32_t evt)
+{
+  uint16_t next = (uint16_t)(e->q_wr + 1u);
+  if ((uint16_t)(next - e->q_rd) > (uint16_t)NAVCORE_EC11_QUEUE_LEN) {
+    // drop oldest to keep most recent
+    e->q_rd++;
+    e->q_overflow++;
+  }
+  e->q[e->q_wr % NAVCORE_EC11_QUEUE_LEN] = (uint16_t)evt;
+  e->q_wr = next;
+}
+
+bool navcore_ec11_pop_event(navcore_ec11_t *e, uint32_t *evt)
+{
+  if (e->q_rd == e->q_wr) return false;
+  uint16_t v = e->q[e->q_rd % NAVCORE_EC11_QUEUE_LEN];
+  e->q_rd++;
+  if (evt) *evt = (uint32_t)v;
+  return true;
+}
+
+// ---- EC11 state (legacy compatibility) ----
+int32_t  g_navcore_ec11_delta = 0;
+
+bool     g_navcore_ec11_sw_short_pressed = false;
+bool     g_navcore_ec11_sw_long_pressed  = false;
+
+// ---- SC16 / streams ----
+static SC16IS750_t g_navcore_sc;
+static TaskHandle_t g_navcore_task = NULL;
+
+static StreamBufferHandle_t g_navcore_gps_sb   = NULL;
+static StreamBufferHandle_t g_navcore_rs485_sb = NULL;
+
+static uint8_t g_sc16_last_gpio_bits = 0xFF;
+
+// --------------------
+// Helpers
+// --------------------
+static inline uint32_t navcore_now_ms(void)
+{
+  return (uint32_t)(esp_timer_get_time() / 1000ULL);
+}
+
+StreamBufferHandle_t rb_navcore_gps_stream(void)   { return g_navcore_gps_sb; }
+StreamBufferHandle_t rb_navcore_rs485_stream(void) { return g_navcore_rs485_sb; }
+
+// Read entire SC16 GPIO port in ONE I2C operation
+static inline uint8_t navcore_sc16_read_gpio_bits(void)
+{
+  return SC16IS750_GPIOGetPortState(&g_navcore_sc);
+}
+
+// --------------------
+// Legacy public getters
+// --------------------
+int32_t NavCore_GetEncoderDelta(void)
+{
+  int32_t d = g_navcore_ec11_delta;
+  g_navcore_ec11_delta = 0;
+  return d;
+}
+
+bool NavCore_GetAndClearSwitchShortPressed(void)
+{
+  bool v = g_navcore_ec11_sw_short_pressed;
+  g_navcore_ec11_sw_short_pressed = false;
+  return v;
+}
+
+bool NavCore_GetAndClearSwitchLongPressed(void)
+{
+  bool v = g_navcore_ec11_sw_long_pressed;
+  g_navcore_ec11_sw_long_pressed = false;
+  return v;
+}
+
+// --------------------
+// Decoder init
+// --------------------
+void navcore_ec11_init(navcore_ec11_t *e)
+{
+    memset(e, 0, sizeof(*e));
+    e->last_ab = 0;
+    e->last_sw = 1; /* pull-up idle */
+    e->last_clk = 0;
+    e->accum = 0;
+    e->last_step_dir = 0;
+    e->last_detent_ms = 0;
+    e->fast_mode = false;
+    e->press_start_ms = 0;
+    e->sw_is_down = false;
+    e->rotation_while_pressed = false;
+    e->last_clk_edge_ms = 0;
+    e->last_sw_edge_ms = 0;
+
+    e->q_wr = 0;
+    e->q_rd = 0;
+    e->q_overflow = 0;
+
+    // Multi short-press aggregation (delayed single)
+    e->short_press_seq = 0;          // 0=no pending, 1=pending single, 2=pending double
+    e->last_short_release_ms = 0;    // deadline (now + window)
+}
+
+
+
+// --------------------
+// Legacy bitmask get/clear
+// --------------------
+uint32_t navcore_ec11_get_and_clear(navcore_ec11_t *e)
+{
+  uint32_t ev = e->events;
+  e->events = 0;
+  return ev;
+}
+
+
+// --------------------
+// Multi Press helper.
+// --------------------
+static inline void navcore_ec11_flush_multi_short_press(navcore_ec11_t *e, uint32_t now_ms)
+{
+    if (e->short_press_seq == 0) return;
+
+    // Deadline reached -> emit final aggregated event
+    if (e->last_short_release_ms != 0u && (uint32_t)(now_ms - e->last_short_release_ms) < 0x80000000u) {
+        // now_ms >= deadline (unsigned safe check via wrap)
+        if (now_ms < e->last_short_release_ms) return;
+    } else {
+        // no deadline => nothing
+        return;
+    }
+
+    if (e->short_press_seq == 1)
+    {
+        e->events |= NAVCORE_EC11_EVT_PRESS;
+        ec11_q_push(e, NAVCORE_EC11_EVT_PRESS);
+        g_navcore_ec11_sw_short_pressed = true;
+    }
+    else if (e->short_press_seq == 2)
+    {
+        e->events |= NAVCORE_EC11_EVT_DOUBLE_PRESS;
+        ec11_q_push(e, NAVCORE_EC11_EVT_DOUBLE_PRESS);
+    }
+
+    // Clear pending state
+    e->short_press_seq = 0;
+    e->last_short_release_ms = 0;
+}
+
+// --------------------
+// CLK-edge-only update
+// - called when SC16 GPIO input change IRQ triggers and CLK or SW changed.
+// - only processes rotation on CLK edge; DT is sampled at that moment.
+// --------------------
+void navcore_ec11_update(navcore_ec11_t *e, uint8_t a, uint8_t b, uint8_t sw, uint32_t now_ms)
+{
+    const uint8_t new_sw = (uint8_t)(sw & 1u);
+    const uint8_t old_sw = (uint8_t)(e->last_sw & 1u);
+
+    const uint8_t new_clk = (uint8_t)(a & 1u);
+    const uint8_t old_clk = (uint8_t)(e->last_clk & 1u);
+
+    // ----------------
+    // Switch handling (press/release with debounce)
+    // ----------------
+    if (new_sw != old_sw)
+    {
+        if (e->last_sw_edge_ms == 0u || (uint32_t)(now_ms - e->last_sw_edge_ms) >= (uint32_t)NAVCORE_EC11_SW_DEBOUNCE_MS)
+        {
+            e->last_sw_edge_ms = now_ms;
+
+            // press: 1 -> 0
+            if (old_sw == 1 && new_sw == 0)
+            {
+                e->press_start_ms = now_ms;
+                e->sw_is_down = true;
+                e->rotation_while_pressed = false;
+                e->long_press_fired = false;
+            }
+            // release: 0 -> 1
+            else if (old_sw == 0 && new_sw == 1)
+            {
+                e->sw_is_down = false;
+
+                uint32_t held = 0;
+                if (e->press_start_ms != 0u) {
+                    held = (uint32_t)(now_ms - e->press_start_ms);
+                }
+                e->press_start_ms = 0;
+
+                // ---------------------------------------------------------
+                // IMPORTANT: If rotation occurred during this press,
+                // DO NOT emit any short/long press (and cancel any pending multi-press).
+                // ---------------------------------------------------------
+                if (e->rotation_while_pressed)
+                {
+                    // Cancel any pending aggregated short press sequence
+                    e->short_press_seq = 0;
+                    e->last_short_release_ms = 0;
+
+                    // End of press cycle
+                    e->rotation_while_pressed = false;
+                    goto save_and_out;
+                }
+
+                // No rotation: normal press logic
+                if (held >= (uint32_t)EC11_LONG_PRESS_MS)
+                {
+                    // Long press cancels any pending short aggregation
+                    e->short_press_seq = 0;
+                    e->last_short_release_ms = 0;
+
+                    e->events |= NAVCORE_EC11_EVT_LONG_PRESS;
+                    ec11_q_push(e, NAVCORE_EC11_EVT_LONG_PRESS);
+                    g_navcore_ec11_sw_long_pressed = true;
+                }
+                else
+                {
+                    // SHORT press: aggregate single/double/triple
+                    // If pending expired, flush it now before starting new sequence
+                    if (e->short_press_seq != 0 && e->last_short_release_ms != 0u && now_ms >= e->last_short_release_ms)
+                    {
+                        navcore_ec11_flush_multi_short_press(e, now_ms);
+                    }
+
+                    if (e->short_press_seq == 0)
+                    {
+                        // Start new sequence (pending single)
+                        e->short_press_seq = 1;
+                        e->last_short_release_ms = (uint32_t)(now_ms + NAVCORE_EC11_MULTI_PRESS_WINDOW_MS);
+                    }
+                    else
+                    {
+                        // Within window: extend sequence
+                        e->short_press_seq++;
+                        e->last_short_release_ms = (uint32_t)(now_ms + NAVCORE_EC11_MULTI_PRESS_WINDOW_MS);
+
+                        if (e->short_press_seq >= 3)
+                        {
+                            // Emit triple immediately and clear
+                            e->events |= NAVCORE_EC11_EVT_TRIPLE_PRESS;
+                            ec11_q_push(e, NAVCORE_EC11_EVT_TRIPLE_PRESS);
+
+                            e->short_press_seq = 0;
+                            e->last_short_release_ms = 0;
+                        }
+                    }
+                }
+
+                // End of press cycle
+                e->rotation_while_pressed = false;
+            }
+        }
+    }
+
+    // ----------------
+    // CLK-edge-only rotation decode (unchanged)
+    // ----------------
+    if (new_clk != old_clk)
+    {
+        if (e->last_clk_edge_ms == 0u || (uint32_t)(now_ms - e->last_clk_edge_ms) >= (uint32_t)NAVCORE_EC11_CLK_DEBOUNCE_MS)
+        {
+            e->last_clk_edge_ms = now_ms;
+
+            // Count only the selected CLK edge
+            if (new_clk != (uint8_t)EC11_COUNT_ON_CLK_LEVEL)
+            {
+                goto save_and_out;
+            }
+
+            // step = +1 if (CLK XOR DT) else -1
+            int8_t step = ((new_clk ^ (uint8_t)(b & 1u)) ? +1 : -1);
+
+#if (NAVCORE_EC11_DIR_INVERT)
+            step = (int8_t)(-step);
 #endif
 
+            e->accum = (int8_t)(e->accum + step);
+            e->last_step_dir = step;
+
+            if (e->accum >= (int8_t)EC11_DETENT_TRANSITIONS || e->accum <= (int8_t)(-EC11_DETENT_TRANSITIONS))
+            {
+                int8_t dir = (e->accum > 0) ? +1 : -1;
+                e->accum = 0;
+
+                // FAST hysteresis
+                if (e->last_detent_ms != 0u)
+                {
+                    uint32_t dt_ms = (uint32_t)(now_ms - e->last_detent_ms);
+                    if (dt_ms <= (uint32_t)NAVCORE_EC11_FAST_ENTER_MS) e->fast_mode = true;
+                    else if (dt_ms >= (uint32_t)NAVCORE_EC11_FAST_EXIT_MS) e->fast_mode = false;
+                }
+                e->last_detent_ms = now_ms;
+
+                // Legacy delta
+                g_navcore_ec11_delta += (int32_t)dir;
+
+                // If rotation while pressed, prevent short/long on release
+                if (e->sw_is_down) e->rotation_while_pressed = true;
+
+                uint32_t evt = 0;
+                if (!e->sw_is_down)
+                {
+                    if (dir > 0) evt = (e->fast_mode ? NAVCORE_EC11_EVT_FAST_CW : NAVCORE_EC11_EVT_CW);
+                    else         evt = (e->fast_mode ? NAVCORE_EC11_EVT_FAST_CCW : NAVCORE_EC11_EVT_CCW);
+                }
+                else
+                {
+                    if (dir > 0) evt = (e->fast_mode ? NAVCORE_EC11_EVT_PRESS_FAST_CW : NAVCORE_EC11_EVT_PRESS_CW);
+                    else         evt = (e->fast_mode ? NAVCORE_EC11_EVT_PRESS_FAST_CCW : NAVCORE_EC11_EVT_PRESS_CCW);
+                }
+
+                if (evt)
+                {
+                    e->events |= evt;
+                    ec11_q_push(e, evt);
+                }
+            }
+        }
+    }
+
+save_and_out:
+    // Save last levels for edge detection
+    e->last_sw  = new_sw;
+    e->last_clk = new_clk;
+    e->last_ab  = (uint8_t)(((new_clk & 1u) << 1) | ((b & 1u)));
+}
 
 
 
+// --------------------
+// Console/UI polling task
+// (already exists in your file; now drains the queue and prints the 10 events)
+// --------------------
+TaskHandle_t g_navcore_ui_task = NULL;
 
+void NavCore_UI_Task(void *arg)
+{
+  (void)arg;
+  const TickType_t period = pdMS_TO_TICKS(20);
+  for (;;) {
+    vTaskDelay(period);
+    navcore_ui_poll_ec11();
+  }
+}
 
-#ifdef RB_ENABLE_NavCore
-// ---- NavCore: Enable the Air Speed Sensor.
-#include "ms4525do_rb.h"
+// --------------------
+// Existing UI/poll handler
+// - Now: drains the queue (ordered) and prints events
+// - Then: keeps your existing "bitmask based" handling (compat)
+// --------------------
+void navcore_ui_poll_ec11(void)
+{
+  // Flush pending single/double when the window expires
+  uint32_t now_ms = (uint32_t)(esp_timer_get_time() / 1000ULL);
+  navcore_ec11_flush_multi_short_press(&g_navcore_ec11, now_ms);
 
+  uint32_t ev = 0;
+  uint32_t one = 0;
 
+  while (navcore_ec11_pop_event(&g_navcore_ec11, &one)) {
+    ev |= one;
 
-// TODO Move into the Singleton
-SC16IS750_t g_navcore_sc;
-bool g_navcore_sc_inited = false;
+  #if NAVCORE_EC11_DEBUG
+    if (one & NAVCORE_EC11_EVT_CW)                printf("[EC11] CW\n");
+    if (one & NAVCORE_EC11_EVT_CCW)               printf("[EC11] CCW\n");
+    if (one & NAVCORE_EC11_EVT_FAST_CW)           printf("[EC11] Fast CW\n");
+    if (one & NAVCORE_EC11_EVT_FAST_CCW)          printf("[EC11] Fast CCW\n");
 
-TaskHandle_t g_navcore_task = NULL;
-StreamBufferHandle_t g_navcore_gps_sb = NULL;
-StreamBufferHandle_t g_navcore_rs485_sb = NULL;
+    if (one & NAVCORE_EC11_EVT_PRESS_CW)          printf("[EC11] CW while Press\n");
+    if (one & NAVCORE_EC11_EVT_PRESS_CCW)         printf("[EC11] CCW while Press\n");
+    if (one & NAVCORE_EC11_EVT_PRESS_FAST_CW)     printf("[EC11] Fast CW while Press\n");
+    if (one & NAVCORE_EC11_EVT_PRESS_FAST_CCW)    printf("[EC11] Fast CCW while Press\n");
 
-volatile int32_t g_navcore_ec11_delta = 0;
-volatile bool    g_navcore_ec11_sw_pressed = false;
+    if (one & NAVCORE_EC11_EVT_PRESS)             printf("[EC11] Short press\n");
+    if (one & NAVCORE_EC11_EVT_LONG_PRESS)        printf("[EC11] Long press (>= %ums)\n", (unsigned)EC11_LONG_PRESS_MS);
 
-// last sampled EC11 pins (2-bit quad state)
-uint8_t g_navcore_ec11_last_ab = 0;
-uint8_t g_navcore_ec11_last_sw = 1;
+    if (one & NAVCORE_EC11_EVT_DOUBLE_PRESS)      printf("[EC11] Double short press\n");
+    if (one & NAVCORE_EC11_EVT_TRIPLE_PRESS)      printf("[EC11] Triple short press\n");
+  #endif
 
+    // ----------------------------
+    // EC11 -> RB02 logical touch mapping
+    // Nord  = CW
+    // Sud   = CCW
+    // Est   = Double press
+    // Ouest = Triple press
+    // ----------------------------
+    if (one & (NAVCORE_EC11_EVT_CW | NAVCORE_EC11_EVT_FAST_CW))
+    {
+      RB02_NavCore_InjectTouch(RB02_TOUCHLOC_N);
+    }
+
+    if (one & (NAVCORE_EC11_EVT_CCW | NAVCORE_EC11_EVT_FAST_CCW))
+    {
+      RB02_NavCore_InjectTouch(RB02_TOUCHLOC_S);
+    }
+
+    if (one & NAVCORE_EC11_EVT_DOUBLE_PRESS)
+    {
+      RB02_NavCore_InjectTouch(RB02_TOUCHLOC_E);
+    }
+
+    if (one & NAVCORE_EC11_EVT_TRIPLE_PRESS)
+    {
+      RB02_NavCore_InjectTouch(RB02_TOUCHLOC_W);
+    }
+  
+  }
+
+  // Clear legacy bitmask (queue already drained)
+  (void)navcore_ec11_get_and_clear(&g_navcore_ec11);
+
+  if (ev == 0) return;
+}
+
+// --------------------
+// SC16 IRQ ISR + SC16 worker task
+// - Inchangé sur le fond: UART A + UART B drainés comme avant
+// - EC11: on ne traite que CLK/SW, et on sample DT sur edge CLK
+// --------------------
 static void IRAM_ATTR navcore_sc16_irq_isr(void *arg)
 {
   (void)arg;
+  BaseType_t hp_task_woken = pdFALSE;
   if (g_navcore_task) {
-    BaseType_t hp = pdFALSE;
-    vTaskNotifyGiveFromISR(g_navcore_task, &hp);
-    if (hp) portYIELD_FROM_ISR();
+    vTaskNotifyGiveFromISR(g_navcore_task, &hp_task_woken);
+  }
+  if (hp_task_woken) {
+    portYIELD_FROM_ISR();
   }
 }
-#endif
 
-
-#ifdef RB_ENABLE_GPS
-#ifdef RB_ENABLE_NavCore
-
-// Decode EC11 quadrature. Table based on 4-bit transition (prev<<2 | curr)
-static inline int8_t navcore_ec11_step(uint8_t prev_ab, uint8_t curr_ab)
-{
-  static const int8_t table[16] = {
-    0, -1, +1, 0,
-    +1, 0, 0, -1,
-    -1, 0, 0, +1,
-    0, +1, -1, 0
-  };
-  return table[((prev_ab & 0x3) << 2) | (curr_ab & 0x3)];
-}
-
-static void navcore_update_ec11(void)
-{
-  uint8_t clk = SC16IS750_GPIOGetPinState(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_CLK) ? 1 : 0;
-  uint8_t dt  = SC16IS750_GPIOGetPinState(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_DT) ? 1 : 0;
-  uint8_t sw  = SC16IS750_GPIOGetPinState(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_SW) ? 1 : 0;
-
-  uint8_t ab = (clk<<1) | dt;
-  int8_t step = navcore_ec11_step(g_navcore_ec11_last_ab, ab);
-  if (step != 0) {
-    g_navcore_ec11_delta += step;
-    g_navcore_ec11_last_ab = ab;
-  } else {
-    g_navcore_ec11_last_ab = ab;
-  }
-
-  // Switch: detect falling edge (assuming pull-up => pressed = 0)
-  if (g_navcore_ec11_last_sw == 1 && sw == 0) {
-    g_navcore_ec11_sw_pressed = true;
-  }
-  g_navcore_ec11_last_sw = sw;
-}
-
-int32_t NavCore_GetEncoderDelta(void)
-{
-  int32_t v = g_navcore_ec11_delta;
-  g_navcore_ec11_delta = 0;
-  return v;
-}
-
-bool NavCore_GetAndClearSwitchPressed(void)
-{
-  bool v = g_navcore_ec11_sw_pressed;
-  g_navcore_ec11_sw_pressed = false;
-  return v;
-}
-
-// Dedicated IRQ-driven task: drains SC16IS interrupts and fills stream buffers.
-// No LVGL / UI calls here.
 static void NavCore_SC16_Task(void *arg)
 {
   (void)arg;
@@ -141,7 +494,7 @@ static void NavCore_SC16_Task(void *arg)
       int16_t evA = SC16IS750_InterruptEventTest(&g_navcore_sc, RB_NAVCORE_GPS_CH);
       int16_t evB = SC16IS750_InterruptEventTest(&g_navcore_sc, RB_NAVCORE_RS485_CH);
 
-      // UART A (GPS): RX or timeout => drain FIFO
+      // UART A (GPS): RX or timeout => drain FIFO into GPS stream buffer
       if (evA == SC16IS750_RHR_INTERRUPT || evA == SC16IS750_RECEIVE_TIMEOUT_INTERRUPT)
       {
         size_t n = 0;
@@ -175,82 +528,107 @@ static void NavCore_SC16_Task(void *arg)
         }
       }
 
-      // GPIO change on A or B: update EC11
+      // GPIO input change (EC11): on ne traite que CLK & SW (DT sampled on CLK edge)
       if (evA == SC16IS750_INPUT_PIN_CHANGE_STATE || evB == SC16IS750_INPUT_PIN_CHANGE_STATE)
       {
-        navcore_update_ec11();
+        uint8_t gpio_bits = navcore_sc16_read_gpio_bits();
+        uint8_t changed   = (uint8_t)(gpio_bits ^ g_sc16_last_gpio_bits);
+        g_sc16_last_gpio_bits = gpio_bits;
+
+        if (changed & (uint8_t)EC11_IRQ_MASK) {
+          uint8_t clk = (gpio_bits & EC11_MASK_CLK) ? 1 : 0;
+          uint8_t dt  = (gpio_bits & EC11_MASK_DT)  ? 1 : 0;
+          uint8_t sw  = (gpio_bits & EC11_MASK_SW)  ? 1 : 0;
+
+          navcore_ec11_update(&g_navcore_ec11, clk, dt, sw, navcore_now_ms());
+        }
       }
     }
   }
 }
 
+// --------------------
+// Init NavCore (SC16 + tasks + ISR)
+// --------------------
+void rb_navcore_init(void)
+{
+    // Create stream buffers if needed (sizes you had before)
+    if (!g_navcore_gps_sb)   g_navcore_gps_sb   = xStreamBufferCreate(2048, 1);
+    if (!g_navcore_rs485_sb) g_navcore_rs485_sb = xStreamBufferCreate(2048, 1);
 
-void NavCore_SC16_Init() {
-   // Create stream buffers once (GPS NMEA bursts + RS485 frames)
-    g_navcore_gps_sb = xStreamBufferCreate(UART_RX_BUF_SIZE * 4, 1);
-    g_navcore_rs485_sb = xStreamBufferCreate(256, 1);
-
+    // Init SC16 on your existing I2C bus (your existing code should be here)
+    // NOTE: I keep your existing init calls as they were in your file, with the key lines below.
     // Init SC16IS: pass 7-bit address (0x4D). The driver uses I2C_Driver.c for transfers.
     SC16IS750_init(&g_navcore_sc, SC16IS750_PROTOCOL_I2C, RB_NAVCORE_SC16IS_ADDR7, 2);
-
     // Configure UART lines (8N1)
     SC16IS750_SetLine(&g_navcore_sc, RB_NAVCORE_GPS_CH, 8, 0, 1);
     SC16IS750_SetLine(&g_navcore_sc, RB_NAVCORE_RS485_CH, 8, 0, 1);
-
     // Baudrates: GPS=9600, RS485=9600 with crystal 1.8432MHz
     SC16IS750_begin(&g_navcore_sc, 9600, 9600, 1843200L);
-
     // FIFO enable + reset
     SC16IS750_FIFOEnable(&g_navcore_sc, RB_NAVCORE_GPS_CH, 1);
     SC16IS750_FIFOReset(&g_navcore_sc, RB_NAVCORE_GPS_CH, 1);
-
     SC16IS750_FIFOEnable(&g_navcore_sc, RB_NAVCORE_RS485_CH, 1);
     SC16IS750_FIFOReset(&g_navcore_sc, RB_NAVCORE_RS485_CH, 1);
-
     // FIFO trigger level (TLR-based): 8 bytes for both channels
     SC16IS750_FIFOSetTriggerLevel(&g_navcore_sc, RB_NAVCORE_GPS_CH, 1, 8);
     SC16IS750_FIFOSetTriggerLevel(&g_navcore_sc, RB_NAVCORE_RS485_CH, 1, 8);
-
     // Enable RX interrupt (Receive timeout events will be reported in IIR when FIFO is enabled)
     SC16IS750_InterruptControl(&g_navcore_sc, RB_NAVCORE_GPS_CH, SC16IS750_INT_RHR);
     SC16IS750_InterruptControl(&g_navcore_sc, RB_NAVCORE_RS485_CH, SC16IS750_INT_RHR);
-
-    // RS485 on channel B using RTSB to drive DE/RE (connect RTSB -> DE/RE)
+      // RS485 on channel B using RTSB to drive DE/RE (connect RTSB -> DE/RE)
     SC16IS750_EnableRs485(&g_navcore_sc, RB_NAVCORE_RS485_CH, NO_INVERT_RTS_SIGNAL);
 
     // EC11 on GPIO0/1/2 of SC16
-    SC16IS750_GPIOSetPinMode(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_CLK, 0);
-    SC16IS750_GPIOSetPinMode(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_DT, 0);
-    SC16IS750_GPIOSetPinMode(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_SW, 0);
-    // Enable GPIO change interrupt for GPIO0..2
-    SC16IS750_SetPinInterrupt(&g_navcore_sc, 0x07);
+    SC16IS750_GPIOSetPinMode(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_CLK, INPUT);
+    SC16IS750_GPIOSetPinMode(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_DT, INPUT);
+    SC16IS750_GPIOSetPinMode(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_SW, INPUT);
+
+    // Enable GPIO change interrupt for GPIO0 & GPIO2 (CLK + SW only)
+    SC16IS750_SetPinInterrupt(&g_navcore_sc, 0b00000101);
 
     // Create dedicated task and IRQ ISR
     xTaskCreate(NavCore_SC16_Task, "navcore_sc16", 4096, NULL, 10, &g_navcore_task);
 
+    // Debug/console task (prints)
+    xTaskCreate(NavCore_UI_Task, "ec11_dbg", 3072, NULL, 5, &g_navcore_ui_task);
+
     gpio_config_t io_conf = {
-      .pin_bit_mask = (1ULL << RB_NAVCORE_SC16_IRQ_GPIO),
-      .mode = GPIO_MODE_INPUT,
-      .pull_up_en = GPIO_PULLUP_ENABLE,
-      .pull_down_en = GPIO_PULLDOWN_DISABLE,
-      .intr_type = GPIO_INTR_NEGEDGE,
+        .pin_bit_mask = (1ULL << RB_NAVCORE_SC16_IRQ_GPIO),
+        .mode = GPIO_MODE_INPUT,
+        .pull_up_en = GPIO_PULLUP_ENABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+        .intr_type = GPIO_INTR_NEGEDGE, // try LOW_LEVEL if you suspect level IRQ
     };
     gpio_config(&io_conf);
+
     esp_err_t isr_err = gpio_install_isr_service(0);
-    if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE) {
-      ESP_ERROR_CHECK(isr_err);
+    if (isr_err != ESP_OK && isr_err != ESP_ERR_INVALID_STATE)
+    {
+        ESP_LOGE("NAVCORE", "gpio_install_isr_service failed: %d", (int)isr_err);
     }
+
     gpio_isr_handler_add(RB_NAVCORE_SC16_IRQ_GPIO, navcore_sc16_irq_isr, NULL);
 
     // Prime EC11 state
-    uint8_t clk = SC16IS750_GPIOGetPinState(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_CLK) ? 1 : 0;
-    uint8_t dt  = SC16IS750_GPIOGetPinState(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_DT) ? 1 : 0;
-    uint8_t sw  = SC16IS750_GPIOGetPinState(&g_navcore_sc, RB_NAVCORE_EC11_GPIO_SW) ? 1 : 0;
-    g_navcore_ec11_last_ab = (clk<<1) | dt;
-    g_navcore_ec11_last_sw = sw;
+    navcore_ec11_init(&g_navcore_ec11);
+    uint8_t gpio_bits = navcore_sc16_read_gpio_bits();
+    g_sc16_last_gpio_bits = gpio_bits;
 
-    g_navcore_sc_inited = true;
+    g_navcore_ec11.last_clk = (gpio_bits & EC11_MASK_CLK) ? 1 : 0;
+    g_navcore_ec11.last_sw  = (gpio_bits & EC11_MASK_SW)  ? 1 : 0;
+    g_navcore_ec11.last_ab  = (uint8_t)(((g_navcore_ec11.last_clk & 1u) << 1) | (((gpio_bits & EC11_MASK_DT) ? 1 : 0) & 1u));
 }
 
-#endif // RB_ENABLE_NavCore
+// Optional debug dump kept (your existing implementation can remain)
+void navcore_ec11_debug_dump(const navcore_ec11_t *e)
+{
+#if NAVCORE_EC11_DEBUG
+    printf("[EC11] q=%u/%u overflow=%u last_clk=%u last_sw=%u fast=%d accum=%d\n",
+           (unsigned)e->q_rd, (unsigned)e->q_wr, (unsigned)e->q_overflow,
+           (unsigned)e->last_clk, (unsigned)e->last_sw,
+           (int)e->fast_mode, (int)e->accum);
+#else
+    (void)e;
 #endif
+}

--- a/main/RB/RB02_NavCore.h
+++ b/main/RB/RB02_NavCore.h
@@ -27,17 +27,111 @@
  * Dual licensing for commercial agreement is available
  *
 */
-#pragma once
-#include "RB02_Config.h"
 
-#ifdef RB_ENABLE_NavCore
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "esp_log.h"
+#include "esp_timer.h"
 #include "sc16is750.h"
 #include "driver/gpio.h"
 #include "freertos/stream_buffer.h"
+#include "driver/uart.h"
+#include "RB02_Defines.h"
+#include "RB02_GUIHelpers.h"
+#include "ms4525do_rb.h"
+#include "BuildMachine.h"
+
+/*
+ * @file navcore.h
+ * Author: The_MiNuS (2025)
+ *
+ * @brief RB02-NavCore board support helpers.
+ *
+ * This module groups together the integration code for the RB02-NavCore board:
+ *  - SC16IS76x (UART/GPIO expander over I2C) handling GPS (port A), RS485 (port B) and EC11 GPIOs
+ *  - MS4525DO differential pressure sensor helper (airspeed)
+ *
+ * Notes:
+ *  - The EC11 signals are pulled-up (4.7 kOhm) and read through SC16 GPIO pins.
+ *  - Interrupt from SC16 is routed to ESP32-S3 GPIO19 on the RB02-NavCore board.
+ *
+ * @details
+ * ## Overall Architecture (RB02-NavCore)
+ *
+ * This module provides the integration “glue” for the RB02-NavCore board,
+ * built around the SC16IS76x I2C UART/GPIO expander and its associated helpers.
+ *
+ * - **u-blox M8 GPS** connected to **UART Port A** of the SC16IS76x.
+ * - **RS485 transceiver** connected to **UART Port B** of the SC16IS76x.
+ * - **EC11 rotary encoder** connected to **SC16IS76x GPIOs**:
+ *   - GPIO0 = CLK, GPIO1 = DT, GPIO2 = SW
+ *   - 4.7kΩ pull-ups (idle = logic '1', pressed = logic '0' for SW)
+ * - **SC16IS76x interrupt line** connected to **ESP32-S3 GPIO19**
+ *   on the RB02-NavCore board.
+ *
+ * ### Execution model (IRQ + periodic polling)
+ * The SC16IS76x can raise an interrupt on GPIO state changes (rotation or button).
+ * To correctly handle **LONG_PRESS** timing even when GPIO levels remain stable,
+ * the design relies on:
+ *
+ * 1) wake-up on SC16IS76x IRQ (GPIO19 edge),
+ * 2) plus a periodic wake-up (e.g. every 20 ms) to maintain button press timing.
+ *
+ * On each wake-up:
+ * - GPIO states are read (preferably in a **single port read**),
+ * - `navcore_ec11_update(...)` is called with (CLK/DT/SW, now_ms),
+ * - the EC11 state machine generates events into its internal queue,
+ * - the UI layer can then consume these events.
+ *
+ * ## EC11 event model
+ * - `navcore_ec11_init()` initializes the EC11 state machine.
+ * - `navcore_ec11_update()` must be called periodically (or on IRQ + tick)
+ *   with the current A/B/SW logic levels.
+ * - `navcore_ec11_pop_event()` retrieves the next EC11 event
+ *   (CW / CCW, FAST, SHORT_PRESS, LONG_PRESS, etc.).
+ *
+ * ### UI integration (RB02 glue)
+ * - `navcore_ui_poll_ec11()` acts as the UI bridge: it consumes EC11 events
+ *   and translates them into UI actions via
+ *   `RB02_NavCore_InjectTouch(...)` (touch-equivalent injection).
+ *
+ * ## GPS / RS485 stream buffers
+ * Bytes received from the SC16IS76x UARTs can be pushed into **FreeRTOS StreamBuffers**
+ * for simple and decoupled consumption by the application:
+ *
+ * - `rb_navcore_gps_stream()`   → GPS StreamBuffer handle
+ * - `rb_navcore_rs485_stream()` → RS485 StreamBuffer handle
+ *
+ * Typical consumption is done using:
+ * `xStreamBufferReceive()` or `xStreamBufferBytesAvailable()`.
+ *
+ * ## Configuration and tuning
+ * Timing parameters (debounce, long press duration, fast rotation threshold, etc.)
+ * are defined using `#define` macros.
+ * Default values are provided in this header and may be overridden before inclusion.
+ */
+
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-#ifdef RB_ENABLE_NavCore
-// ---- NavCore: SC16IS762/752 via existing I2C bus (GPIO07/15) + IRQ on GPIO19 ----
+/*
+ * @brief EC11 rotary encoder state machine.
+ *
+ * This state machine expects A/B/SW sampled at a regular cadence.
+ * It outputs events such as CW/CCW, fast turns and button presses.
+*/
+
+// ===============================
+// Streams (GPS / RS485) for RB02
+// ===============================
+StreamBufferHandle_t rb_navcore_gps_stream(void);
+StreamBufferHandle_t rb_navcore_rs485_stream(void);
+
+// ---- NavCore: SC16IS762/752 via existing I2C bus (GPIO07/15) + IRQ on GPIO19 --
 #define RB_NAVCORE_SC16IS_ADDR7          0x4D
 #define RB_NAVCORE_GPS_CH                SC16IS750_CHANNEL_A
 #define RB_NAVCORE_RS485_CH              SC16IS750_CHANNEL_B
@@ -48,27 +142,188 @@
 #define RB_NAVCORE_EC11_GPIO_DT          1
 #define RB_NAVCORE_EC11_GPIO_SW          2
 
+// ===============================
+// Events
+// ===============================
+typedef enum {
+    NAVCORE_EC11_EVT_NONE            = 0,
 
-extern SC16IS750_t g_navcore_sc;
-extern bool g_navcore_sc_inited;
+    NAVCORE_EC11_EVT_CW              = (1u << 0),
+    NAVCORE_EC11_EVT_CCW             = (1u << 1),
+    NAVCORE_EC11_EVT_FAST_CW         = (1u << 2),
+    NAVCORE_EC11_EVT_FAST_CCW        = (1u << 3),
 
-extern TaskHandle_t g_navcore_task;
-extern StreamBufferHandle_t g_navcore_gps_sb;
-extern StreamBufferHandle_t g_navcore_rs485_sb;
+    NAVCORE_EC11_EVT_PRESS           = (1u << 4),  /* short press (on release) */
+    NAVCORE_EC11_EVT_LONG_PRESS      = (1u << 5),  /* long press (on release)  */
 
-extern volatile int32_t g_navcore_ec11_delta;
-extern volatile bool    g_navcore_ec11_sw_pressed;
+    NAVCORE_EC11_EVT_PRESS_CW        = (1u << 6),
+    NAVCORE_EC11_EVT_PRESS_CCW       = (1u << 7),
+    NAVCORE_EC11_EVT_PRESS_FAST_CW   = (1u << 8),
+    NAVCORE_EC11_EVT_PRESS_FAST_CCW  = (1u << 9),
 
-// last sampled EC11 pins (2-bit quad state)
-extern uint8_t g_navcore_ec11_last_ab;
-extern uint8_t g_navcore_ec11_last_sw;
+    NAVCORE_EC11_EVT_DOUBLE_PRESS   = (1u << 10),
+    NAVCORE_EC11_EVT_TRIPLE_PRESS   = (1u << 11),
+
+} navcore_ec11_evt_t;
 
 
+#define RB02_TOUCHLOC_N      1u
+#define RB02_TOUCHLOC_W      3u
+#define RB02_TOUCHLOC_CENTER 4u
+#define RB02_TOUCHLOC_E      5u
+#define RB02_TOUCHLOC_S      7u
+
+void RB02_NavCore_InjectTouch(uint8_t touch_loc);
+
+// ===============================
+// EC11 tuning (CLK-edge-only decode)
+// ===============================
+
+#ifndef NAVCORE_EC11_DIR_INVERT
+#define NAVCORE_EC11_DIR_INVERT 1
 #endif
-#ifdef RB_ENABLE_NavCore
-static void NavCore_SC16_Task(void *arg);
-int32_t NavCore_GetEncoderDelta(void);
-bool NavCore_GetAndClearSwitchPressed(void);
-static void IRAM_ATTR navcore_sc16_irq_isr(void *arg);
-void NavCore_SC16_Init();
+
+// With CLK-edge-only decode, a detent typically produces 2 CLK edges
+#define EC11_DETENT_TRANSITIONS  1
+
+// Choix de l'edge utilisé pour compter : 0 = falling, 1 = rising
+#define EC11_COUNT_ON_CLK_LEVEL  0
+
+// Long press threshold (evaluated on release)
+#define EC11_LONG_PRESS_MS       2000u
+
+// Masks on SC16 GPIO port bitmap
+#define EC11_MASK_CLK   (1u << RB_NAVCORE_EC11_GPIO_CLK)
+#define EC11_MASK_DT    (1u << RB_NAVCORE_EC11_GPIO_DT)
+#define EC11_MASK_SW    (1u << RB_NAVCORE_EC11_GPIO_SW)
+#define EC11_IRQ_MASK   (EC11_MASK_CLK | EC11_MASK_SW)
+
+// Fast hysteresis already used in your code
+#ifndef NAVCORE_EC11_FAST_ENTER_MS
+#define NAVCORE_EC11_FAST_ENTER_MS 90u
+#endif
+
+#ifndef NAVCORE_EC11_FAST_EXIT_MS
+#define NAVCORE_EC11_FAST_EXIT_MS 150u
+#endif
+
+#define NAVCORE_EC11_TRACE_LEN 128
+
+#ifndef NAVCORE_EC11_QUEUE_LEN
+#define NAVCORE_EC11_QUEUE_LEN 32
+#endif
+
+#ifndef NAVCORE_EC11_CLK_DEBOUNCE_MS
+#define NAVCORE_EC11_CLK_DEBOUNCE_MS 1u
+#endif
+
+#ifndef NAVCORE_EC11_SW_DEBOUNCE_MS
+#define NAVCORE_EC11_SW_DEBOUNCE_MS 10u
+#endif
+
+#ifndef NAVCORE_EC11_MULTI_PRESS_WINDOW_MS
+#define NAVCORE_EC11_MULTI_PRESS_WINDOW_MS 400u
+#endif
+
+// ===============================
+// State
+// ===============================
+typedef struct navcore_ec11_s {
+
+    /* Last sampled A/B as a 2-bit value: (a<<1)|b */
+    uint8_t  last_ab;
+
+    /* Last sampled switch state: 0 pressed, 1 released */
+    uint8_t  last_sw;
+
+    /* CLK-edge-only decode support (DT sampled on CLK edge) */
+    uint8_t  last_clk;
+    uint32_t last_clk_edge_ms;
+    uint32_t last_sw_edge_ms;
+
+    /* Ordered event queue to avoid losing events when UI polls slowly */
+    uint16_t q_wr;
+    uint16_t q_rd;
+    uint16_t q_overflow;
+    uint16_t q[NAVCORE_EC11_QUEUE_LEN];
+
+    /* Accumulator of valid transitions; emits a detent when abs(accum) reaches
+     * EC11_DETENT_TRANSITIONS.
+     */
+    int8_t   accum;
+
+    /* Last non-zero step direction (+1 / -1). */
+    int8_t   last_step_dir;
+
+    /* Timestamp tracking for speed / press handling */
+    uint32_t last_detent_ms;
+    uint32_t press_start_ms;
+
+    /* Speed classification */
+    uint32_t fast_enter_ms;
+    uint32_t fast_exit_ms;
+    bool     fast_mode;
+    bool     sw_is_down;
+
+    /* Button behaviour */
+    bool     long_press_fired;
+    bool     rotation_while_pressed;
+
+    uint32_t last_short_release_ms;
+    uint8_t  short_press_seq;
+
+    uint32_t events; /* legacy bitmask compatibility */
+
+    struct navcore_ec11_trace_s {
+        uint32_t t_ms;
+        uint8_t old_ab;
+        uint8_t new_ab;
+        int8_t  step;
+        int8_t  accum_before;
+        uint8_t sw;
+        uint8_t flags; /* bit0 invalid, bit1 detent, bit2 fast */
+        int8_t  detent_dir;
+    } trace[NAVCORE_EC11_TRACE_LEN];
+    uint16_t trace_wr;
+
+} navcore_ec11_t;
+
+// ===============================
+// API
+// ===============================
+/** @brief Initialize an EC11 state machine instance. */
+void     navcore_ec11_init(navcore_ec11_t *e);
+
+/*
+ * @brief Initialize RB02-NavCore peripherals (SC16IS76x, EC11 GPIOs, etc.).
+ *
+ * This function is application-glue: it expects RB02 project macros (GPIO mapping, etc.).
+*/
+void     rb_navcore_init(void);
+
+/*
+ * @brief Feed new sampled A/B/SW states into the EC11 state machine.
+ * @param now_ms Current time in milliseconds (monotonic).
+*/
+void     navcore_ec11_update(navcore_ec11_t *e, uint8_t a, uint8_t b, uint8_t sw, uint32_t now_ms);
+
+// Legacy bitmask (compat)
+uint32_t navcore_ec11_get_and_clear(navcore_ec11_t *e);
+
+// Ordered queue pop (new)
+/*
+ * @brief Pop the next pending EC11 event from the internal queue.
+ * @return true if an event was returned, false if the queue was empty.
+*/
+bool     navcore_ec11_pop_event(navcore_ec11_t *e, uint32_t *evt);
+
+// Existing UI poll (now drains queue and prints)
+/* @brief RB02 UI glue: poll/dispatch EC11 events and inject them into the UI navigation. */
+void navcore_ui_poll_ec11(void);
+
+/** @brief Dump the EC11 internal state for debugging (ESP_LOG). */
+void navcore_ec11_debug_dump(const navcore_ec11_t *e);
+
+#ifdef __cplusplus
+} // extern "C"
 #endif


### PR DESCRIPTION
This PR Fix the EC11 Driver and enable Interrupt mode instead of polling.
It also introduce 12 different actions that can be used to substitute to gesture.
 - CW/CCW
 - Fast CW/CCW
 - Press + CW/CCW
 - Press + Fast CW/CCW
 - Short Preww
 - Dual Short Press
 - Triple Short Press
 - Long Press (<2s)

I mapped for test purpose:
- Dual Short Press -> next page (equivalent to Touch Ouest).
- Triple Short Press -> previous page (equivalent to Touch Est).
- CW/CCW -> equivalent to Touch Noth/South.

I aslo added a missing CmakeList.txt

I also fixed license for the MS4525DO that was written by Myself and not nopnop2002.

The MiNuS